### PR TITLE
feat: compute rank sum via histogram

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pdex"
-version = "0.1.23"
+version = "0.1.24"
 description = "Parallel differential expression for single-cell perturbation sequencing"
 readme = "README.md"
 authors = [{ name = "noam teyssier", email = "noam.teyssier@arcinstitute.org" }]


### PR DESCRIPTION
This PR includes a optimization to the experimental path that avoids an expensive sorting operation since we know the rank data will be non negative integers. This helps reduce an ~O(n log n) to a ~O(n + k) operation

test file on vcc data `de.py`

```python
import anndata as ad
from pdex._single_cell import (
    parallel_differential_expression_vec_wrapper as parallel_differential_expression,
)
import time

start_time = time.time()

adata = ad.read_h5ad("../bspc/convert/vcc_data/adata_Training.h5ad")

ctrl_mask = adata.obs["target_gene"] == "non-targeting"
control_cells = adata[ctrl_mask]

results = parallel_differential_expression(
    adata,
    reference="non-targeting",
    groupby_key="target_gene",
)

filtered = results[results["fdr"] < 0.05]

end_time = time.time()

duration_seconds = end_time - start_time
print(f"Duration: {duration_seconds:.2f} s")

```

### without changes

```bash
uv run de.py
```

```
INFO:pdex._single_cell:vectorized processing: 151 targets, 18080 genes
INFO:pdex._single_cell:Processing 150 targets
Processing targets: 100%|████████████| 150/150 [04:38<00:00,  1.85s/it]
         target      reference  ...   statistic           fdr
1         ACAT2  non-targeting  ...  32283650.0  1.438159e-02
3         ACAT2  non-targeting  ...  32960683.0  6.131963e-03
6         ACAT2  non-targeting  ...  27410824.5  8.822740e-41
7         ACAT2  non-targeting  ...  30923579.5  8.424997e-08
13        ACAT2  non-targeting  ...  31345804.5  9.959514e-06
...         ...            ...  ...         ...           ...
2711585  ZNF714  non-targeting  ...  17262619.5  5.069960e-03
2711638  ZNF714  non-targeting  ...  16298170.0  4.070273e-04
2711788  ZNF714  non-targeting  ...  15356470.0  1.301370e-02
2711819  ZNF714  non-targeting  ...  14222770.0  7.139213e-09
2711881  ZNF714  non-targeting  ...  17164012.5  2.931495e-02

[497142 rows x 10 columns]
Duration: 301.64 s
```

### with changes

```bash
uv run de.py
```

```
INFO:pdex._single_cell:vectorized processing: 151 targets, 18080 genes
INFO:pdex._single_cell:Processing 150 targets
Processing targets: 100%|████████████| 150/150 [01:38<00:00,  1.52it/s]
         target      reference  ...   statistic           fdr
1         ACAT2  non-targeting  ...  32283650.0  1.438150e-02
3         ACAT2  non-targeting  ...  32960683.0  6.131919e-03
6         ACAT2  non-targeting  ...  27410824.5  8.822600e-41
7         ACAT2  non-targeting  ...  30923579.5  8.424943e-08
13        ACAT2  non-targeting  ...  31345804.5  9.959460e-06
...         ...            ...  ...         ...           ...
2711585  ZNF714  non-targeting  ...  17262619.5  5.069928e-03
2711638  ZNF714  non-targeting  ...  16298170.0  4.069336e-04
2711788  ZNF714  non-targeting  ...  15356470.0  1.301359e-02
2711819  ZNF714  non-targeting  ...  14222770.0  7.139142e-09
2711881  ZNF714  non-targeting  ...  17164012.5  2.931467e-02

[497144 rows x 10 columns]
Duration: 120.82 s
```

TLDR; this results in a total runtime of ~`1:38` on my MacBook M3 vs ~`4:38` or about ~`58%` speedup 
