### PR TITLE
fix: correct pvalue logic and add discretization step

### DIFF
--- a/src/pdex/_single_cell.py
+++ b/src/pdex/_single_cell.py
@@ -4,6 +4,7 @@ import multiprocessing as mp
 from collections.abc import Iterator
 from functools import partial
 from multiprocessing.shared_memory import SharedMemory
+from typing import Callable
 
 import anndata as ad
 import os
@@ -443,6 +444,9 @@ def prepare_ranksum_buffers(X_target, X_ref):
     return K_cols, pool_cnt, pool_cnt_t
 
 
+SQRT2 = math.sqrt(2.0)
+
+
 @njit(parallel=True, fastmath=True)
 def ranksum_kernel_with_pool(X_target, X_ref, K_cols, pool_cnt, pool_cnt_t):
     n_t = X_target.shape[0]
@@ -452,7 +456,7 @@ def ranksum_kernel_with_pool(X_target, X_ref, K_cols, pool_cnt, pool_cnt_t):
     p_values = np.empty(n_genes, dtype=np.float64)
     u_stats = np.empty(n_genes, dtype=np.float64)
 
-    for j in prange(n_genes):
+    for j in prange(n_genes):  # type: ignore[not-iterable]
         tid = get_thread_id()  # Numba ≥ 0.56
         cnt = pool_cnt[tid]
         cnt_t = pool_cnt_t[tid]
@@ -482,19 +486,17 @@ def ranksum_kernel_with_pool(X_target, X_ref, K_cols, pool_cnt, pool_cnt_t):
 
         # U and p
         u = rank_sum_target - 0.5 * n_t * (n_t + 1)
-        u_stats[j] = u
+        u2 = n_t * n_r - u
+        u_min = u if u > u2 else u2
 
-        N = n_t + n_r
-        if N > 1:
-            tie_adj = tie_sum / (N * (N - 1))
-            sigma2 = (n_t * n_r) * ((N + 1) - tie_adj) / 12.0
-            if sigma2 > 0.0:
-                z = (u - 0.5 * n_t * n_r) / math.sqrt(sigma2)
-                p_values[j] = math.erfc(abs(z) / math.sqrt(2.0))
-            else:
-                p_values[j] = 1.0
-        else:
-            p_values[j] = 1.0
+        n = n_t + n_r
+        s = np.sqrt(n_t * n_r / 12 * ((n + 1) - tie_sum / (n * (n - 1))))
+        mean = n_t * n_r / 2.0
+        cc = 0.5 if u_min < mean else -0.5 if u_min > mean else 0.0
+        z_corr = (u_min - mean + cc) / s
+        p_corr = math.erfc(abs(z_corr) / SQRT2)
+        u_stats[j] = u_min
+        p_values[j] = p_corr if s > 0.0 else 1.0
 
         # clear just the touched slice
         for v in range(Kp1_use):
@@ -525,6 +527,8 @@ def _process_single_target_vectorized(
     obs_values: np.ndarray,
     X: np.ndarray,
     X_ref: np.ndarray,
+    X_disc: np.ndarray,
+    X_ref_disc: np.ndarray,
     means_ref: np.ndarray,
     gene_names: np.ndarray,
     is_log1p: bool,
@@ -538,6 +542,7 @@ def _process_single_target_vectorized(
     # Get target data
     target_mask = obs_values == target
     X_target = X[target_mask, :]
+    X_target_disc = X_disc[target_mask, :]
 
     # Vectorized means calculation
     if is_log1p:
@@ -563,7 +568,8 @@ def _process_single_target_vectorized(
         pcc = np.where(means_ref == 0, np.nan, pcc)
 
     # Statistical tests across all genes simultaneously
-    p_values, statistics = _vectorized_ranksum_test_numba(X_target, X_ref)
+    p_values, statistics = _vectorized_ranksum_test_numba(X_target_disc, X_ref_disc)
+    pairwise_fdr = false_discovery_control(p_values, method="bh")
 
     # Build results for all genes at once using vectorized operations
     target_results = [
@@ -577,6 +583,7 @@ def _process_single_target_vectorized(
             "fold_change": fc[i],
             "p_value": p_values[i],
             "statistic": statistics[i],
+            "pairwise_fdr": pairwise_fdr[i],
         }
         for i in range(len(gene_names))
     ]
@@ -637,6 +644,68 @@ def parallel_differential_expression_vec(
     targets_to_process = [target for target in unique_targets if target != reference]
     gene_names = adata.var.index.values
 
+    is_discrete = np.issubdtype(X.dtype, np.integer) and np.issubdtype(
+        X_ref.dtype, np.integer
+    )
+    if is_discrete:
+        logger.info("Data appears discrete - using direct integer representation")
+        X_disc = X.astype(np.int32, copy=False)
+        X_ref_disc = X_ref.astype(np.int32, copy=False)
+    else:
+        logger.info("Data appears continuous - discretizing to integer representation")
+        import time
+
+        start_discretization = time.time()
+
+        # Discretize data to the smallest integer range while preserving order
+        X_f = np.asarray(X, dtype=np.float32, order="C")
+
+        # Handle NaNs/Infs
+        if not np.isfinite(X_f).all():
+            X_f = np.nan_to_num(
+                X_f,
+                nan=0.0,
+                posinf=np.finfo(np.float32).max,
+                neginf=np.finfo(np.float32).min,
+            )
+
+        X_min = float(np.min(X_f))
+        X_max = float(np.max(X_f))
+
+        # Shift if needed
+        if X_min < 0.0:
+            X_f = X_f - X_min
+            X_ref = X_ref - X_min
+            X_max = X_max - X_min
+
+        # Degenerate case: all values identical
+        if X_max <= 0.0:
+            X_disc = np.zeros_like(X_f, dtype=np.int32)
+            X_ref_disc = np.zeros_like(X_ref, dtype=np.int32)
+        else:
+            # Scale into the *smallest* integer range: 0..N where N = number of distinct values - 1
+            # If continuous, fallback to full dynamic range of int32
+            unique_vals = np.unique(X_f)
+            if unique_vals.shape[0] < 1_000_000:  # heuristic: treat as discrete
+                mapping = {v: i for i, v in enumerate(np.unique(unique_vals))}
+                # Vectorized mapping with np.searchsorted
+                idxs = np.searchsorted(unique_vals, X_f.ravel()).reshape(X_f.shape)
+                X_disc = idxs.astype(np.int32)
+                idxs_ref = np.searchsorted(unique_vals, X_ref.ravel()).reshape(
+                    X_ref.shape
+                )
+                X_ref_disc = idxs_ref.astype(np.int32)
+            else:
+                # Continuous → scale to full int32 range
+                scale = np.iinfo(np.int32).max / X_max
+                X_disc = np.rint(X_f * scale).astype(np.int32, copy=False)
+                X_ref_disc = np.rint(X_ref * scale).astype(np.int32, copy=False)
+
+        end_discretization = time.time()
+        logger.info(
+            f"Discretization completed in {end_discretization - start_discretization:.2f} seconds"
+        )
+
     # Process targets sequentially with numba functions
     logger.info(f"Processing {len(targets_to_process)} targets")
     all_results = []
@@ -647,6 +716,8 @@ def parallel_differential_expression_vec(
             obs_values=obs_values,  # type: ignore
             X=X,
             X_ref=X_ref,
+            X_disc=X_disc,
+            X_ref_disc=X_ref_disc,
             means_ref=means_ref,
             gene_names=gene_names,  # type: ignore
             is_log1p=is_log1p,
@@ -695,4 +766,6 @@ def parallel_differential_expression_vec_wrapper(
 
 if use_experimental:
     logger.warning("Using experimental features")
-    parallel_differential_expression = parallel_differential_expression_vec_wrapper
+    parallel_differential_expression: Callable = (
+        parallel_differential_expression_vec_wrapper
+    )


### PR DESCRIPTION
This PR supersedes https://github.com/ArcInstitute/pdex/pull/53 and ensures that the experimental output is identical to the current output with a relative accuracy of `<1e-6` and absolute accuracy of `<1e-12`. 

Additionally this PR renames and improves the `tests/bench_expr.py` file. The new `tests/test_experimental_correctness.py` file will run with the other test (prefixed with `test_`) and compares the output between the reference and experimental outputs to ensure they are within a extremely small tolerance

note these changes slow down the overall computation by a small amount (mainly when the discretization step is needed) which can be avoid but providing a the raw integer data

```bash
uv run tests/test_experimental_correctness.py
```

```txt
======================================================== test session starts ========================================================
platform darwin -- Python 3.10.15, pytest-8.4.1, pluggy-1.6.0
benchmark: 5.1.0 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: /Users/drbh/Projects/pdex
configfile: pyproject.toml
plugins: benchmark-5.1.0
collected 9 items

tests/test_experimental_correctness.py .........                                                                              [100%]

========================================================= warnings summary ==========================================================
tests/test_experimental_correctness.py::test_correctness_comparison
tests/test_experimental_correctness.py::test_detailed_correctness_metrics
tests/test_experimental_correctness.py::test_edge_cases_numerical_stability
tests/test_experimental_correctness.py::test_edge_cases_numerical_stability
  /Users/drbh/Projects/pdex/.venv/lib/python3.10/site-packages/anndata/_core/aligned_df.py:68: ImplicitModificationWarning: Transforming to str index.
    warnings.warn("Transforming to str index.", ImplicitModificationWarning)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html

------------------------------------------------------------------------------------------------------------ benchmark: 6 tests ------------------------------------------------------------------------------------------------------------
Name (time in ms)                                                    Min                   Max                  Mean             StdDev                Median                IQR            Outliers       OPS            Rounds  Iterations
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_benchmark_parameterized_datasets[True-500-100-10]            7.3009 (1.0)          8.3150 (1.0)          7.9079 (1.0)       0.4193 (1.0)          7.9405 (1.0)       0.6697 (1.0)           1;0  126.4562 (1.0)           5           1
test_benchmark_parameterized_datasets[True-1000-300-100]         81.2446 (11.13)       83.1028 (9.99)        82.1008 (10.38)     0.7036 (1.68)        82.1472 (10.35)     0.9652 (1.44)          2;0   12.1802 (0.10)          5           1
test_benchmark_parameterized_datasets[True-2000-500-50]         113.6737 (15.57)      124.0537 (14.92)      118.8101 (15.02)     4.5535 (10.86)      119.7459 (15.08)     8.1712 (12.20)         2;0    8.4168 (0.07)          5           1
test_benchmark_parameterized_datasets[False-500-100-10]       1,121.4055 (153.60)   1,163.2690 (139.90)   1,146.4066 (144.97)   15.3490 (36.61)    1,150.1841 (144.85)   13.6819 (20.43)         2;0    0.8723 (0.01)          5           1
test_benchmark_parameterized_datasets[False-2000-500-50]      3,598.1983 (492.84)   3,636.3652 (437.33)   3,620.5203 (457.84)   14.3509 (34.23)    3,620.4431 (455.95)   17.2623 (25.78)         2;0    0.2762 (0.00)          5           1
test_benchmark_parameterized_datasets[False-1000-300-100]     3,952.2674 (541.34)   4,037.7101 (485.59)   3,976.9548 (502.91)   34.6742 (82.70)    3,966.9077 (499.58)   30.1742 (45.06)         1;1    0.2514 (0.00)          5           1
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

Legend:
  Outliers: 1 Standard Deviation from Mean; 1.5 IQR (InterQuartile Range) from 1st Quartile and 3rd Quartile.
  OPS: Operations Per Second, computed as 1 / Mean
============================================= 9 passed, 4 warnings in 71.21s (0:01:11) ==============================================
```