### PR TITLE
ci: enforce semver bump on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,15 @@ jobs:
 
       - name: check version bump
         run: |
-          BASE_VERSION=$(git show origin/${{ github.base_ref }}:pyproject.toml | grep '^version' | sed 's/version = "\(.*\)"/\1/')
-          PR_VERSION=$(grep '^version' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
+          BASE_VERSION=$(git show origin/${{ github.base_ref }}:pyproject.toml \
+            | python3 -c "import sys, tomllib; print(tomllib.load(sys.stdin.buffer)['project']['version'])")
+          PR_VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
           echo "Base version: $BASE_VERSION"
           echo "PR version:   $PR_VERSION"
+          if [ -z "$BASE_VERSION" ] || [ -z "$PR_VERSION" ]; then
+            echo "ERROR: failed to parse version from pyproject.toml"
+            exit 1
+          fi
           if [ "$BASE_VERSION" = "$PR_VERSION" ]; then
             echo "ERROR: version in pyproject.toml ($PR_VERSION) must be bumped before merging."
             exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,36 @@ on: [push, pull_request]
 jobs:
   all_jobs:
     runs-on: ubuntu-latest
-    needs: [formatting, type-checking, pytest]
+    needs: [formatting, type-checking, pytest, semver-check]
+    if: always()
     steps:
       - name: Complete
-        run: echo "Complete"
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then
+            echo "One or more required jobs failed."
+            exit 1
+          fi
+          echo "Complete"
+
+  semver-check:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: check version bump
+        run: |
+          BASE_VERSION=$(git show origin/${{ github.base_ref }}:pyproject.toml | grep '^version' | sed 's/version = "\(.*\)"/\1/')
+          PR_VERSION=$(grep '^version' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
+          echo "Base version: $BASE_VERSION"
+          echo "PR version:   $PR_VERSION"
+          if [ "$BASE_VERSION" = "$PR_VERSION" ]; then
+            echo "ERROR: version in pyproject.toml ($PR_VERSION) must be bumped before merging."
+            exit 1
+          fi
 
   install-job:
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pdex"
-version = "0.2.0"
+version = "0.2.1"
 description = "Parallel differential expression for single-cell perturbation sequencing"
 readme = "README.md"
 authors = [{ name = "noam teyssier", email = "noam.teyssier@arcinstitute.org" }]


### PR DESCRIPTION
## Summary
- Adds a `semver-check` CI job that runs on every pull request
- Compares the `version` field in `pyproject.toml` against the base branch
- Fails with a clear error if the version has not been bumped

## Changes
- `.github/workflows/ci.yml`: new `semver-check` job with `if: github.event_name == 'pull_request'` guard
- `all_jobs` gate updated with `if: always()` + explicit failure check so the skipped `semver-check` on direct pushes doesn't block the gate

## Test plan
- [x] Open a PR without bumping the version → `semver-check` fails with clear error message
- [x] Open a PR with a bumped version → `semver-check` passes
- [ ] Push directly to a branch (non-PR) → `semver-check` skipped, `all_jobs` still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)